### PR TITLE
Crash detect, chat channels, fixed mcchat, improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.3</version>
+				<version>3.6.2</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>

--- a/src/main/java/buttondevteam/discordplugin/DiscordConnectedPlayer.java
+++ b/src/main/java/buttondevteam/discordplugin/DiscordConnectedPlayer.java
@@ -12,8 +12,8 @@ public class DiscordConnectedPlayer extends DiscordFakePlayer implements IMCPlay
 	private static int nextEntityId = 10000;
 	private @Getter VanillaCommandListener<DiscordConnectedPlayer> vanillaCmdListener;
 
-	public DiscordConnectedPlayer(IUser user, IChannel channel, UUID uuid) {
-		super(user, channel, nextEntityId++, uuid);
+	public DiscordConnectedPlayer(IUser user, IChannel channel, UUID uuid, String mcname) {
+		super(user, channel, nextEntityId++, uuid, mcname);
 		vanillaCmdListener = new VanillaCommandListener<>(this);
 	}
 

--- a/src/main/java/buttondevteam/discordplugin/DiscordPlugin.java
+++ b/src/main/java/buttondevteam/discordplugin/DiscordPlugin.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Random;
 
 import org.bukkit.Bukkit;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitTask;
@@ -183,6 +184,8 @@ public class DiscordPlugin extends JavaPlugin implements IListener<ReadyEvent> {
 	@Override
 	public void onDisable() {
 		stop = true;
+		for(val entry : MCChatListener.ConnectedSenders.entrySet())
+			MCListener.callEventExcluding(new PlayerQuitEvent(entry.getValue(), ""), "ProtocolLib");
 		getConfig().set("lastannouncementtime", lastannouncementtime);
 		getConfig().set("lastseentime", lastseentime);
 		getConfig().set("gameroles", GameRoles);
@@ -218,7 +221,7 @@ public class DiscordPlugin extends JavaPlugin implements IListener<ReadyEvent> {
 				for (int i = json.size() - 1; i >= 0; i--) {
 					JsonObject item = json.get(i).getAsJsonObject();
 					final JsonObject data = item.get("data").getAsJsonObject();
-					String author = "/u/" + data.get("author").getAsString();
+					String author = data.get("author").getAsString();
 					JsonElement distinguishedjson = data.get("distinguished");
 					String distinguished;
 					if (distinguishedjson.isJsonNull())
@@ -239,6 +242,8 @@ public class DiscordPlugin extends JavaPlugin implements IListener<ReadyEvent> {
 							if (id != null)
 								author = "<@" + id + ">";
 						} while (false);
+						if (!author.startsWith("<"))
+							author = "/u/" + author;
 						(distinguished != null && distinguished.equals("moderator") ? modmsgsb : msgsb)
 								.append("A new post was submitted to the subreddit by ").append(author).append("\n")
 								.append(permalink).append("\n");

--- a/src/main/java/buttondevteam/discordplugin/DiscordPlugin.java
+++ b/src/main/java/buttondevteam/discordplugin/DiscordPlugin.java
@@ -20,6 +20,8 @@ import buttondevteam.discordplugin.listeners.*;
 import buttondevteam.discordplugin.mccommands.DiscordMCCommandBase;
 import buttondevteam.lib.TBMCCoreAPI;
 import buttondevteam.lib.chat.TBMCChatAPI;
+import buttondevteam.lib.player.ChromaGamerBase;
+import lombok.val;
 import net.milkbowl.vault.permission.Permission;
 import sx.blah.discord.api.*;
 import sx.blah.discord.api.events.IListener;
@@ -67,6 +69,7 @@ public class DiscordPlugin extends JavaPlugin implements IListener<ReadyEvent> {
 	 */
 	public static IChannel officechannel;
 	public static IChannel updatechannel;
+	public static IChannel devofficechannel;
 	public static IGuild mainServer;
 	public static IGuild devServer;
 
@@ -91,6 +94,7 @@ public class DiscordPlugin extends JavaPlugin implements IListener<ReadyEvent> {
 					botroomchannel = devServer.getChannelByID(239519012529111040L); // bot-room
 					officechannel = devServer.getChannelByID(219626707458457603L); // developers-office
 					updatechannel = devServer.getChannelByID(233724163519414272L); // server-updates
+					devofficechannel = officechannel; // developers-office
 					dc.online("on TBMC");
 				} else {
 					botchannel = devServer.getChannelByID(239519012529111040L); // bot-room
@@ -100,6 +104,7 @@ public class DiscordPlugin extends JavaPlugin implements IListener<ReadyEvent> {
 					chatchannel = botchannel;// bot-room
 					officechannel = devServer.getChannelByID(219626707458457603L); // developers-office
 					updatechannel = botchannel;
+					devofficechannel = botchannel;// bot-room
 					dc.online("testing");
 				}
 				if (botchannel == null || annchannel == null || genchannel == null || botroomchannel == null
@@ -109,17 +114,26 @@ public class DiscordPlugin extends JavaPlugin implements IListener<ReadyEvent> {
 				if (task != null)
 					task.cancel();
 				if (!sent) {
-					sendMessageToChannel(chatchannel, "", new EmbedBuilder().withColor(Color.GREEN)
-							.withTitle("Server started - chat connected.").build());
-					try {
-						List<IMessage> msgs = genchannel.getPinnedMessages();
-						for (int i = msgs.size() - 1; i >= 10; i--) { // Unpin all pinned messages except the newest 10
-							genchannel.unpin(msgs.get(i));
-							Thread.sleep(10);
+					if (getConfig().getBoolean("serverup", false)) {
+						sendMessageToChannel(chatchannel, "", new EmbedBuilder().withColor(Color.YELLOW)
+								.withTitle("Server recovered from a crash - chat connected.").build());
+						TBMCCoreAPI.SendException("The server crashed!", new Throwable(
+								"The server shut down unexpectedly. See the log of the previous run for more details."));
+					} else
+						sendMessageToChannel(chatchannel, "", new EmbedBuilder().withColor(Color.GREEN)
+								.withTitle("Server started - chat connected.").build());
+					getConfig().set("serverup", true);
+					saveConfig();
+					perform(() -> {
+						try {
+							List<IMessage> msgs = genchannel.getPinnedMessages();
+							for (int i = msgs.size() - 1; i >= 10; i--) { // Unpin all pinned messages except the newest 10
+								genchannel.unpin(msgs.get(i));
+								Thread.sleep(10);
+							}
+						} catch (InterruptedException e) {
 						}
-					} catch (Exception e) {
-						TBMCCoreAPI.SendException("Error occured while unpinning messages!", e);
-					}
+					});
 					sent = true;
 				}
 			}, 0, 10);
@@ -172,6 +186,7 @@ public class DiscordPlugin extends JavaPlugin implements IListener<ReadyEvent> {
 		getConfig().set("lastannouncementtime", lastannouncementtime);
 		getConfig().set("lastseentime", lastseentime);
 		getConfig().set("gameroles", GameRoles);
+		getConfig().set("serverup", false);
 		saveConfig();
 		sendMessageToChannel(chatchannel, "", new EmbedBuilder().withColor(Restart ? Color.ORANGE : Color.RED)
 				.withTitle(Restart ? "Server restarting" : "Server stopping").build());
@@ -203,7 +218,7 @@ public class DiscordPlugin extends JavaPlugin implements IListener<ReadyEvent> {
 				for (int i = json.size() - 1; i >= 0; i--) {
 					JsonObject item = json.get(i).getAsJsonObject();
 					final JsonObject data = item.get("data").getAsJsonObject();
-					String author = data.get("author").getAsString();
+					String author = "/u/" + data.get("author").getAsString();
 					JsonElement distinguishedjson = data.get("distinguished");
 					String distinguished;
 					if (distinguishedjson.isJsonNull())
@@ -215,6 +230,15 @@ public class DiscordPlugin extends JavaPlugin implements IListener<ReadyEvent> {
 					if (date > lastseentime)
 						lastseentime = date;
 					else if (date > lastannouncementtime) {
+						do {
+							val reddituserclass = ChromaGamerBase.getTypeForFolder("reddit");
+							if (reddituserclass == null)
+								break;
+							val user = ChromaGamerBase.getUser(author, reddituserclass);
+							String id = user.getConnectedID(DiscordPlayer.class);
+							if (id != null)
+								author = "<@" + id + ">";
+						} while (false);
 						(distinguished != null && distinguished.equals("moderator") ? modmsgsb : msgsb)
 								.append("A new post was submitted to the subreddit by ").append(author).append("\n")
 								.append(permalink).append("\n");

--- a/src/main/java/buttondevteam/discordplugin/DiscordSenderBase.java
+++ b/src/main/java/buttondevteam/discordplugin/DiscordSenderBase.java
@@ -9,7 +9,11 @@ import org.bukkit.Bukkit;
 import org.bukkit.scheduler.BukkitTask;
 
 import buttondevteam.lib.TBMCCoreAPI;
+import buttondevteam.lib.chat.Channel;
 import buttondevteam.lib.chat.IDiscordSender;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
 import sx.blah.discord.handle.obj.IChannel;
 import sx.blah.discord.handle.obj.IUser;
 
@@ -19,6 +23,7 @@ public abstract class DiscordSenderBase implements IDiscordSender {
 	 */
 	protected IUser user;
 	protected IChannel channel;
+	private @Getter @Setter @NonNull Channel mcchannel = Channel.GlobalChat;
 
 	protected DiscordSenderBase(IUser user, IChannel channel) {
 		this.user = user;

--- a/src/main/java/buttondevteam/discordplugin/listeners/CommandListener.java
+++ b/src/main/java/buttondevteam/discordplugin/listeners/CommandListener.java
@@ -8,11 +8,15 @@ import buttondevteam.discordplugin.DiscordPlayer;
 import buttondevteam.discordplugin.DiscordPlugin;
 import buttondevteam.discordplugin.commands.DiscordCommandBase;
 import buttondevteam.lib.TBMCCoreAPI;
+import lombok.val;
 import sx.blah.discord.api.events.IListener;
 import sx.blah.discord.handle.impl.events.guild.channel.message.MentionEvent;
 import sx.blah.discord.handle.impl.events.guild.channel.message.MessageReceivedEvent;
+import sx.blah.discord.handle.impl.events.user.PresenceUpdateEvent;
 import sx.blah.discord.handle.obj.IChannel;
 import sx.blah.discord.handle.obj.IMessage;
+import sx.blah.discord.handle.obj.StatusType;
+import sx.blah.discord.util.EmbedBuilder;
 
 public class CommandListener {
 
@@ -88,6 +92,22 @@ public class CommandListener {
 				if (event.getMessage().getAuthor().isBot())
 					return;
 				runCommand(event.getMessage(), false);
+			}
+		}, new IListener<sx.blah.discord.handle.impl.events.user.PresenceUpdateEvent>() {
+			@Override
+			public void handle(PresenceUpdateEvent event) {
+				val devrole = DiscordPlugin.devServer.getRolesByName("Developer").get(0);
+				if (event.getOldPresence().getStatus().equals(StatusType.OFFLINE)
+						&& !event.getNewPresence().getStatus().equals(StatusType.OFFLINE)
+						&& event.getUser().getRolesForGuild(DiscordPlugin.devServer).stream()
+								.anyMatch(r -> r.getLongID() == devrole.getLongID())
+						&& DiscordPlugin.devServer.getUsersByRole(devrole).stream()
+								.noneMatch(u -> u.getPresence().getStatus().equals(StatusType.OFFLINE)))
+					DiscordPlugin.sendMessageToChannel(DiscordPlugin.devofficechannel, "Full house!",
+							new EmbedBuilder()
+									.withImage(
+											"https://cdn.discordapp.com/attachments/249295547263877121/249687682618359808/poker-hand-full-house-aces-kings-playing-cards-15553791.png")
+									.build());
 			}
 		} };
 	}

--- a/src/main/java/buttondevteam/discordplugin/listeners/CommandListener.java
+++ b/src/main/java/buttondevteam/discordplugin/listeners/CommandListener.java
@@ -146,7 +146,7 @@ public class CommandListener {
 			cmd = cmdwithargs.substring(0, index);
 			args = cmdwithargs.substring(index + 1);
 		}
-		DiscordCommandBase.runCommand(cmd, args, message);
+		DiscordCommandBase.runCommand(cmd.toLowerCase(), args, message);
 		message.getChannel().setTypingStatus(false);
 		return true;
 	}

--- a/src/main/java/buttondevteam/discordplugin/listeners/MCChatListener.java
+++ b/src/main/java/buttondevteam/discordplugin/listeners/MCChatListener.java
@@ -42,8 +42,9 @@ public class MCChatListener implements Listener, IListener<MessageReceivedEvent>
 						.withDescription(e.getMessage()).withColor(new Color(e.getChannel().color.getRed(),
 								e.getChannel().color.getGreen(), e.getChannel().color.getBlue()));
 				if (e.getSender() instanceof Player)
-					embed.withAuthorIcon(
-							"https://minotar.net/avatar/" + ((Player) e.getSender()).getName() + "/32.png");
+					embed.withAuthorIcon("https://minotar.net/avatar/" + ((Player) e.getSender()).getName() + "/32.png")
+							.withAuthorUrl("https://tbmcplugins.github.io/profile.html?type=minecraft&id="
+									+ ((Player) e.getSender()).getUniqueId()); // TODO: Constant/method to get URLs like this
 				final long nanoTime = System.nanoTime();
 				Consumer<LastMsgData> doit = lastmsgdata -> {
 					final EmbedObject embedObject = embed.build();
@@ -79,7 +80,7 @@ public class MCChatListener implements Listener, IListener<MessageReceivedEvent>
 						doit.accept(data);
 				}
 			}
-		}); // TODO: Author URL
+		});
 	}
 
 	private static class LastMsgData {
@@ -247,8 +248,7 @@ public class MCChatListener implements Listener, IListener<MessageReceivedEvent>
 								.findAny();
 						if (!ch.isPresent())
 							VanillaCommandListener.runBukkitOrVanillaCommand(dsender, cmd);
-						else // TO!DO: Only allow talking in general in public chat - A to-do from before I went to Greece
-						{
+						else {
 							Channel chc = ch.get();
 							if (!chc.ID.equals(Channel.GlobalChat.ID) && !event.getMessage().getChannel().isPrivate())
 								dsender.sendMessage(
@@ -266,7 +266,8 @@ public class MCChatListener implements Listener, IListener<MessageReceivedEvent>
 					}
 					lastlistp = (short) Bukkit.getOnlinePlayers().size();
 				} else {// Not a command
-					if (dmessage.length() == 0 && event.getMessage().getAttachments().size() == 0)
+					if (dmessage.length() == 0 && event.getMessage().getAttachments().size() == 0
+							&& !event.getChannel().isPrivate())
 						TBMCChatAPI.SendChatMessage(Channel.GlobalChat, dsender, "pinned a message on Discord."); // TODO: Not chat message
 					else
 						sendChatMessage.accept(dsender.getMcchannel(), dmessage);

--- a/src/main/java/buttondevteam/discordplugin/listeners/MCChatListener.java
+++ b/src/main/java/buttondevteam/discordplugin/listeners/MCChatListener.java
@@ -134,11 +134,11 @@ public class MCChatListener implements Listener, IListener<MessageReceivedEvent>
 				val sender = new DiscordConnectedPlayer(user, channel, mcp.getUUID());
 				ConnectedSenders.put(user.getStringID(), sender);
 				if (p == null)// Player is offline - If the player is online, that takes precedence
-					Bukkit.getPluginManager().callEvent(new PlayerJoinEvent(sender, ""));
+					MCListener.callEventExcluding(new PlayerJoinEvent(sender, ""), "ProtocolLib");
 			} else {
 				val sender = ConnectedSenders.remove(user.getStringID());
 				if (p == null)// Player is offline - If the player is online, that takes precedence
-					Bukkit.getPluginManager().callEvent(new PlayerQuitEvent(sender, ""));
+					MCListener.callEventExcluding(new PlayerQuitEvent(sender, ""), "ProtocolLib");
 			}
 		}
 		return start //

--- a/src/main/java/buttondevteam/discordplugin/listeners/MCChatListener.java
+++ b/src/main/java/buttondevteam/discordplugin/listeners/MCChatListener.java
@@ -238,8 +238,10 @@ public class MCChatListener implements Listener, IListener<MessageReceivedEvent>
 					{
 						dsender.sendMessage("Stop it. You know the answer.");
 						lastlist = 0;
-					} else
+					} else {
+						String topcmd = null; // TODO: Channels
 						VanillaCommandListener.runBukkitOrVanillaCommand(dsender, cmd);
+					}
 					lastlistp = (short) Bukkit.getOnlinePlayers().size();
 				} else {
 					if (dmessage.length() == 0 && event.getMessage().getAttachments().size() == 0)

--- a/src/main/java/buttondevteam/discordplugin/listeners/MCListener.java
+++ b/src/main/java/buttondevteam/discordplugin/listeners/MCListener.java
@@ -26,6 +26,7 @@ import buttondevteam.discordplugin.DiscordPlayerSender;
 import buttondevteam.discordplugin.DiscordPlugin;
 import buttondevteam.discordplugin.commands.ConnectCommand;
 import buttondevteam.lib.TBMCCoreAPI;
+import buttondevteam.lib.TBMCSystemChatEvent;
 import buttondevteam.lib.player.*;
 import lombok.val;
 import net.ess3.api.events.*;
@@ -128,6 +129,11 @@ public class MCListener implements Listener {
 			TBMCCoreAPI.SendException("Failed to give/take Muted role to player " + e.getAffected().getName() + "!",
 					ex);
 		}
+	}
+
+	@EventHandler
+	public void onChatSystemMessage(TBMCSystemChatEvent event) {
+		MCChatListener.sendSystemMessageToChat(event);
 	}
 
 	/**

--- a/src/main/java/buttondevteam/discordplugin/listeners/MCListener.java
+++ b/src/main/java/buttondevteam/discordplugin/listeners/MCListener.java
@@ -1,14 +1,22 @@
 package buttondevteam.discordplugin.listeners;
 
+import java.util.Arrays;
+import java.util.logging.Level;
+
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
+import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.server.ServerCommandEvent;
+import org.bukkit.plugin.AuthorNagException;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.RegisteredListener;
 
 import com.earth2me.essentials.CommandSource;
 
@@ -41,7 +49,7 @@ public class MCListener implements Listener {
 					new DiscordPlayerSender(user, DiscordPlugin.chatchannel, p));
 			MCChatListener.ConnectedSenders.values().stream()
 					.filter(s -> s.getUniqueId().equals(e.getPlayer().getUniqueId())).findAny()
-					.ifPresent(dcp -> Bukkit.getPluginManager().callEvent(new PlayerQuitEvent(dcp, "")));
+					.ifPresent(dcp -> callEventExcluding(new PlayerQuitEvent(dcp, ""), "ProtocolLib"));
 		}
 		if (ConnectCommand.WaitingToConnect.containsKey(e.GetPlayer().PlayerName().get())) {
 			IUser user = DiscordPlugin.dc
@@ -62,7 +70,7 @@ public class MCListener implements Listener {
 				.removeIf(entry -> entry.getValue().getUniqueId().equals(e.getPlayer().getUniqueId()));
 		MCChatListener.ConnectedSenders.values().stream()
 				.filter(s -> s.getUniqueId().equals(e.getPlayer().getUniqueId())).findAny()
-				.ifPresent(dcp -> Bukkit.getPluginManager().callEvent(new PlayerJoinEvent(dcp, "")));
+				.ifPresent(dcp -> callEventExcluding(new PlayerJoinEvent(dcp, ""), "ProtocolLib"));
 		MCChatListener.sendSystemMessageToChat(e.GetPlayer().PlayerName().get() + " left the game");
 	}
 
@@ -119,6 +127,64 @@ public class MCListener implements Listener {
 		} catch (DiscordException | MissingPermissionsException ex) {
 			TBMCCoreAPI.SendException("Failed to give/take Muted role to player " + e.getAffected().getName() + "!",
 					ex);
+		}
+	}
+
+	/**
+	 * Calls an event with the given details.
+	 * <p>
+	 * This method only synchronizes when the event is not asynchronous.
+	 *
+	 * @param event
+	 *            Event details
+	 * @param plugins
+	 *            The plugins to exclude. Not case sensitive.
+	 */
+	public static void callEventExcluding(Event event, String... plugins) { // Copied from Spigot-API and modified a bit
+		if (event.isAsynchronous()) {
+			if (Thread.holdsLock(Bukkit.getPluginManager())) {
+				throw new IllegalStateException(
+						event.getEventName() + " cannot be triggered asynchronously from inside synchronized code.");
+			}
+			if (Bukkit.getServer().isPrimaryThread()) {
+				throw new IllegalStateException(
+						event.getEventName() + " cannot be triggered asynchronously from primary server thread.");
+			}
+			fireEventExcluding(event, plugins);
+		} else {
+			synchronized (Bukkit.getPluginManager()) {
+				fireEventExcluding(event, plugins);
+			}
+		}
+	}
+
+	private static void fireEventExcluding(Event event, String... plugins) {
+		HandlerList handlers = event.getHandlers(); // Code taken from SimplePluginManager in Spigot-API
+		RegisteredListener[] listeners = handlers.getRegisteredListeners();
+		val server = Bukkit.getServer();
+
+		for (RegisteredListener registration : listeners) {
+			if (!registration.getPlugin().isEnabled()
+					|| Arrays.stream(plugins).anyMatch(p -> p.equalsIgnoreCase(registration.getPlugin().getName())))
+				continue; // Modified to exclude plugins
+
+			try {
+				registration.callEvent(event);
+			} catch (AuthorNagException ex) {
+				Plugin plugin = registration.getPlugin();
+
+				if (plugin.isNaggable()) {
+					plugin.setNaggable(false);
+
+					server.getLogger().log(Level.SEVERE,
+							String.format("Nag author(s): '%s' of '%s' about the following: %s",
+									plugin.getDescription().getAuthors(), plugin.getDescription().getFullName(),
+									ex.getMessage()));
+				}
+			} catch (Throwable ex) {
+				server.getLogger().log(Level.SEVERE, "Could not pass event " + event.getEventName() + " to "
+						+ registration.getPlugin().getDescription().getFullName(), ex);
+			}
 		}
 	}
 }

--- a/src/main/java/buttondevteam/discordplugin/playerfaker/DiscordFakePlayer.java
+++ b/src/main/java/buttondevteam/discordplugin/playerfaker/DiscordFakePlayer.java
@@ -16,22 +16,21 @@ import org.bukkit.scoreboard.Scoreboard;
 
 import buttondevteam.discordplugin.DiscordPlugin;
 import lombok.experimental.Delegate;
+import lombok.Getter;
 import sx.blah.discord.handle.obj.IChannel;
 import sx.blah.discord.handle.obj.IUser;
 
 public class DiscordFakePlayer extends DiscordHumanEntity implements Player {
-	protected DiscordFakePlayer(IUser user, IChannel channel, int entityId, UUID uuid) {
+	protected DiscordFakePlayer(IUser user, IChannel channel, int entityId, UUID uuid, String mcname) {
 		super(user, channel, entityId, uuid);
 		perm = new PermissibleBase(Bukkit.getOfflinePlayer(uuid));
+		name = mcname;
 	}
 
 	@Delegate
 	private PermissibleBase perm;
 
-	@Override
-	public String getName() {
-		return user.getName();
-	}
+	private @Getter String name;
 
 	@Override
 	public EntityType getType() {


### PR DESCRIPTION
* Crash detect, will post if the server shut down unexpectedly
* When announcing a Reddit post, it will use Discord names whenever possible (although Reddit users aren't saved separately yet, so it doesn't work)
* It should print "full house" when all developers get online
* Added chat channel support
* Bot commands can be in any case
* Fixed ProtocolLib error on fake player join/leave by leaving it out of the fun
* It'll automatically "kick" fake players on disable
* Private pins won't be announced in chat
* Player names are clickable and they link to the user's (soon to be actually implemeted) profile using either the Minecraft or Discord ID
* Chat rooms implemented (probably)
* Fixed fake user name, some plugins depend on MC name - Players will
need to relog into mcchat if their name changed
* Fixed join-while-mcchat in ButtonCore
* Fixed Discord->MC messages showing up in inccorect places on Discord
* Fixed chat channel feedback
* Other fixes